### PR TITLE
새로운 콘서트에 따른 콘서트 좌석 데이터 생성 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ COPY . .
 RUN gradle build -x test --no-daemon
 
 # 실행 스테이지
-FROM --platform=linux/amd64 eclipse-temurin:17-jdk-alpine
+FROM --platform=linux/amd64 eclipse-temurin:17-jdk-jammy
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar","app.jar"]
-ㅇ

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: eclipse-temurin:17-jdk-alpine
+    image: eclipse-temurin:17-jdk-jammy
     platform: linux/amd64
     volumes:
       - ./build/libs:/app
@@ -15,6 +15,12 @@ services:
       SPRING_DATASOURCE_URL:  jdbc:h2:tcp://h2:1521/test
       SPRING_DATASOURCE_USERNAME: sa
       SPRING_DATASOURCE_PASSWORD: 1234
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
   h2:
     image: oscarfonts/h2:latest
     container_name: h2-database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       SPRING_DATASOURCE_URL:  jdbc:h2:tcp://h2:1521/test
       SPRING_DATASOURCE_USERNAME: sa
       SPRING_DATASOURCE_PASSWORD: 1234
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
   h2:
     image: oscarfonts/h2:latest
     container_name: h2-database

--- a/src/main/java/com/jerry/ticketing/Repository/seat/SectionRepository.java
+++ b/src/main/java/com/jerry/ticketing/Repository/seat/SectionRepository.java
@@ -1,8 +1,0 @@
-package com.jerry.ticketing.Repository.seat;
-
-import com.jerry.ticketing.domain.seat.Section;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface SectionRepository extends JpaRepository<Section,Long> {
-
-}

--- a/src/main/java/com/jerry/ticketing/api/concert/ConcertController.java
+++ b/src/main/java/com/jerry/ticketing/api/concert/ConcertController.java
@@ -1,0 +1,33 @@
+package com.jerry.ticketing.api.concert;
+
+import com.jerry.ticketing.application.concert.ConcertService;
+import com.jerry.ticketing.dto.request.ConcertCreateRequest;
+import com.jerry.ticketing.dto.response.ConcertResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/concert")
+@RequiredArgsConstructor
+public class ConcertController {
+
+
+    private final ConcertService concertService;
+
+    /**
+     * 새로운 콘서스 생성
+     * */
+    @PostMapping
+    public ResponseEntity<ConcertResponse> createConcert(
+            @Valid @RequestBody ConcertCreateRequest request){
+        ConcertResponse createdConcert = concertService.createConcert(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdConcert);
+
+    }
+
+
+}

--- a/src/main/java/com/jerry/ticketing/api/seat/SeatBlockingController.java
+++ b/src/main/java/com/jerry/ticketing/api/seat/SeatBlockingController.java
@@ -21,6 +21,9 @@ import java.util.stream.Collectors;
 public class SeatBlockingController {
     private final SeatBlockingService seatBlockingService;
 
+    /**
+     * 좌석 선점
+     * */
     @PostMapping("/block")
     public ResponseEntity<SeatBlockingResponse> blockSeats(@RequestBody SeatBlockingRequest request) {
 

--- a/src/main/java/com/jerry/ticketing/application/concert/ConcertService.java
+++ b/src/main/java/com/jerry/ticketing/application/concert/ConcertService.java
@@ -1,0 +1,46 @@
+package com.jerry.ticketing.application.concert;
+
+import com.jerry.ticketing.application.seat.ConcertSeatInitializer;
+import com.jerry.ticketing.domain.concert.Concert;
+import com.jerry.ticketing.dto.request.ConcertCreateRequest;
+import com.jerry.ticketing.dto.response.ConcertResponse;
+import com.jerry.ticketing.exception.BusinessException;
+import com.jerry.ticketing.exception.ConcertErrorCode;
+import com.jerry.ticketing.repository.concert.ConcertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertService {
+
+    private final ConcertRepository concertRepository;
+    private final ConcertSeatInitializer concertSeatInitializer;
+
+    @Transactional
+    public ConcertResponse createConcert(ConcertCreateRequest request){
+
+        try{
+            Concert concert = Concert.builder()
+                    .title(request.getTitle())
+                    .dateTime(request.getDateTime())
+                    .venue(request.getVenue())
+                    .price(request.getPrice())
+                    .description(request.getDescription())
+                    .maxTicketsPerUser(request.getMaxTicketsPerUser())
+                    .build();
+
+            Concert saveConcert = concertRepository.save(concert);
+
+            // 좌석 & 섹션 초기화
+            concertSeatInitializer.initializeSectionAndConcertSeats(saveConcert.getId());
+
+            return ConcertResponse.from(saveConcert);
+
+        }catch (Exception e){
+            throw new BusinessException(ConcertErrorCode.CONCERT_SAVE_FAILED);
+        }
+
+    }
+}

--- a/src/main/java/com/jerry/ticketing/application/seat/ConcertSeatInitializer.java
+++ b/src/main/java/com/jerry/ticketing/application/seat/ConcertSeatInitializer.java
@@ -1,0 +1,146 @@
+package com.jerry.ticketing.application.seat;
+
+
+import com.jerry.ticketing.domain.concert.Concert;
+import com.jerry.ticketing.domain.seat.ConcertSeat;
+import com.jerry.ticketing.domain.seat.Seat;
+import com.jerry.ticketing.domain.seat.Section;
+import com.jerry.ticketing.domain.seat.enums.ConcertSeatStatus;
+import com.jerry.ticketing.repository.concert.ConcertRepository;
+import com.jerry.ticketing.repository.seat.ConcertSeatRepository;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import com.jerry.ticketing.repository.seat.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ConcertSeatInitializer {
+
+    private final SeatRepository seatRepository;
+    private final SectionRepository sectionRepository;
+    private final ConcertRepository concertRepository;
+    private final ConcertSeatRepository concertSeatRepository;
+
+     // 좌석 생성 배치 크기
+     private static final int BATCH_SIZE = 1000;
+
+
+    /**
+     * 구역과 콘서트 좌석 데이터를 생성합니다.
+     * */
+    public void initializeSectionAndConcertSeats(Long concertId){
+
+        if (sectionRepository.existsByConcertId(concertId)) {
+            log.info("콘서트 좌석 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+        log.info("콘서트 좌석과 구역을 초기화를 시작합니다...");
+        initializeAllSectionAndConcertSeats(concertId);
+        log.info("콘서트 좌석과 구역 데이터 초기화가 완료되었습니다.");
+
+    }
+
+
+    /**
+     * Section과 ConcertSeat 모든 초기화 데이터 생성합니다.
+     * */
+    protected void initializeAllSectionAndConcertSeats(Long concertId) {
+        Section section = createSectionIfNotExists(concertId);
+        if (concertSeatRepository.findByConcertId(concertId).isEmpty()){
+            createConcertSeats(concertId, section);
+        }
+    }
+
+
+    /**
+     * Section A-Z 까지 만듭니다.
+     * @param concertId 콘서트 아이디
+     * */
+    private Section createSectionIfNotExists(Long concertId) {
+        return sectionRepository.findByConcertId(concertId)
+                .orElseGet(() -> {
+                    List<Section> createdSections = new ArrayList<>();
+                    List<SectionConfig> configs = getSectionConfigs();
+
+                    Concert concert = concertRepository.findById(concertId)
+                            .orElseThrow(() -> new RuntimeException("Concert not found"));
+
+                    for (SectionConfig config : configs) {
+                        for (char zone = config.getStartZone(); zone <= config.getEndZone(); zone++) {
+                            Section section = Section.builder()
+                                    .concert(concert)
+                                    .zone(String.valueOf(zone))
+                                    .capacity(config.getCapacity())
+                                    .remainingSeats(config.getCapacity())
+                                    .build();
+
+                            createdSections.add(sectionRepository.save(section));
+                        }
+                    }
+                    return createdSections.isEmpty() ? null : createdSections.get(0);
+                });
+    }
+
+
+    /**
+     * ConcertSeat을 Section, Concert, Seat에 매핑
+     * @param section 콘서트 아이디
+     */
+    private void createConcertSeats(Long concertId, Section section) {
+        List<ConcertSeat> concertSeatBatch = new ArrayList<>(BATCH_SIZE);
+        long currentCreatedCount = 1L;
+        int totalCreated = 0;
+
+        List<SectionConfig> configs = getSectionConfigs();
+        Concert concert = concertRepository.findById(concertId).orElse(null);
+
+        for (SectionConfig config : configs) {
+            for (char zone = config.getStartZone(); zone <= config.getEndZone(); zone++) {
+                for (char rowChar = config.getStartRow(); rowChar <= config.getEndRow(); rowChar++) {
+                    for (int number = config.getStartNumber(); number <= config.getEndNumber(); number++) {
+                        Seat seat = seatRepository.findById(currentCreatedCount++).orElse(null);
+
+                        ConcertSeat concertSeat = ConcertSeat.builder()
+                                .concert(concert)
+                                .seat(seat)
+                                .section(section)
+                                .price((concert != null ? concert.getPrice() : 0) * config.getPremium())
+                                .status(ConcertSeatStatus.AVAILABLE)
+                                .blockedBy(null)
+                                .blockedAt(null)
+                                .blockedExpireAt(null)
+                                .build();
+
+                        concertSeatBatch.add(concertSeat);
+                        if (concertSeatBatch.size() >= BATCH_SIZE){
+                            concertSeatRepository.saveAll(concertSeatBatch);
+                            totalCreated += concertSeatBatch.size();
+                            concertSeatBatch.clear();
+                            log.debug("{}개 콘서트 좌석 저장 완료", totalCreated);
+                        }
+
+                    }
+                }
+                if(!concertSeatBatch.isEmpty()){
+                    concertSeatRepository.saveAll(concertSeatBatch);
+                    totalCreated += concertSeatBatch.size();
+                }
+            }
+        }
+
+        log.debug("총 {}개 콘서트 좌석 생성 완료", totalCreated);
+    }
+
+    private static List<SectionConfig> getSectionConfigs() {
+        return List.of(
+                SectionConfig.vipSection(), SectionConfig.standardSection(), SectionConfig.economySection()
+        );
+    }
+
+}

--- a/src/main/java/com/jerry/ticketing/application/seat/SeatBlockingService.java
+++ b/src/main/java/com/jerry/ticketing/application/seat/SeatBlockingService.java
@@ -6,7 +6,7 @@ import com.jerry.ticketing.domain.seat.enums.ConcertSeatStatus;
 import com.jerry.ticketing.exception.BusinessException;
 import com.jerry.ticketing.exception.SeatErrorCode;
 import com.jerry.ticketing.repository.seat.ConcertSeatRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/jerry/ticketing/application/seat/SeatInitializer.java
+++ b/src/main/java/com/jerry/ticketing/application/seat/SeatInitializer.java
@@ -1,0 +1,94 @@
+package com.jerry.ticketing.application.seat;
+
+
+import com.jerry.ticketing.domain.seat.Seat;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SeatInitializer {
+
+
+    // 좌석 생성 배치 크기
+    private static final int BATCH_SIZE = 1000;
+
+    private final SeatRepository seatRepository;
+
+    /**
+     * 초기 좌석(VO객체)을 생성합니다.
+     * */
+    public void initializeSeats(){
+
+        if (seatRepository.count()>0) {
+            log.info("좌석 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+        log.info("좌석 초기화를 시작합니다...");
+        initializeAllSeats();
+        log.info("좌석 데이터 초기화가 완료되었습니다.");
+    }
+
+
+    /**
+     * 애플리케이션 시작 시 좌석 데이터 초기화 데이터 지정합니다.
+     * */
+    protected void initializeAllSeats(){
+        for(char zone = 'A'; zone<= 'F'; zone ++){
+            createSeats(SectionConfig.vipSection());
+        }
+
+        for(char zone = 'G'; zone<= 'L'; zone ++){
+            createSeats(SectionConfig.standardSection());
+        }
+
+        for(char zone = 'M'; zone<= 'Z'; zone ++){
+            createSeats(SectionConfig.economySection());
+        }
+
+    }
+
+
+    /**
+     * Section Config를 기반으로 실제 Seat 객체를 생성합니다.
+     * */
+    private void createSeats(SectionConfig config) {
+        List<Seat> seatBatch = new ArrayList<>(BATCH_SIZE);
+        int totalCreated = 0;
+
+        for (char rowChar = config.getStartRow(); rowChar <= config.getEndRow(); rowChar++) {
+            String row = String.valueOf(rowChar);
+            for (int number = config.getStartNumber(); number <= config.getEndNumber(); number++) {
+                Seat seat = Seat.builder()
+                        .seatRow(row)
+                        .number(number)
+                        .seatType(config.getSeatType())
+                        .build();
+
+                seatBatch.add(seat);
+
+                if (seatBatch.size() >= BATCH_SIZE){
+                    seatRepository.saveAll(seatBatch);
+                    totalCreated += seatBatch.size();
+                    seatBatch.clear();
+                    log.debug("{}개 좌석 저장 완료", totalCreated);
+                }
+            }
+        }
+
+        if(!seatBatch.isEmpty()){
+            seatRepository.saveAll(seatBatch);
+            totalCreated += seatBatch.size();
+        }
+
+        log.debug("총 {}개 좌석 생성 완료", totalCreated);
+    }
+
+}
+

--- a/src/main/java/com/jerry/ticketing/application/seat/SectionConfig.java
+++ b/src/main/java/com/jerry/ticketing/application/seat/SectionConfig.java
@@ -1,0 +1,44 @@
+package com.jerry.ticketing.application.seat;
+
+import com.jerry.ticketing.domain.seat.enums.SeatType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 구역 설정 정보 클래스
+ * */
+@AllArgsConstructor
+@Getter
+public class SectionConfig {
+    private int capacity;
+    private char startZone;
+    private char endZone;
+    private char startRow;
+    private char endRow;
+    private int startNumber;
+    private int endNumber;
+    private SeatType seatType;
+    private int premium;
+
+    public static SectionConfig vipSection(){
+        return new SectionConfig(1000,'A','F','a', 'j', 1, 100, SeatType.VIP,3);
+    }
+
+    public static SectionConfig standardSection(){
+        return new SectionConfig(1500, 'G','L','a', 'o', 1, 100, SeatType.STANDARD,2);
+    }
+
+    public static SectionConfig economySection(){
+        return new SectionConfig(2000, 'M','Z','a', 't', 1, 100, SeatType.ECONOMY,1);
+    }
+
+    public static int calculateSeats(SectionConfig sectionConfig){
+        return ((int)(sectionConfig.getEndRow() - sectionConfig.getStartRow()) + 1 ) * sectionConfig.getEndNumber();
+    }
+
+    public static int currentSeats(SectionConfig sectionConfig, char row, int number){
+        return sectionConfig.getEndNumber() * (int) (row - 'a') + number;
+    }
+
+
+}

--- a/src/main/java/com/jerry/ticketing/config/runner/SeatInitializerRunner.java
+++ b/src/main/java/com/jerry/ticketing/config/runner/SeatInitializerRunner.java
@@ -1,0 +1,21 @@
+package com.jerry.ticketing.config.runner;
+
+import com.jerry.ticketing.application.seat.SeatInitializer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatInitializerRunner implements CommandLineRunner {
+    private final SeatInitializer seatInitializer;
+
+    @Override
+    public void run(String ...args){
+            seatInitializer.initializeSeats();
+    }
+
+}

--- a/src/main/java/com/jerry/ticketing/domain/concert/Concert.java
+++ b/src/main/java/com/jerry/ticketing/domain/concert/Concert.java
@@ -31,6 +31,10 @@ public class Concert {
     @Column(nullable = false)
     private String venue;
 
+    // 콘서트 가격
+    @Column(nullable = false)
+    private int price;
+
     // 콘서트 설명
     private String description;
 

--- a/src/main/java/com/jerry/ticketing/domain/concert/Concert.java
+++ b/src/main/java/com/jerry/ticketing/domain/concert/Concert.java
@@ -3,7 +3,7 @@ package com.jerry.ticketing.domain.concert;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -25,7 +25,7 @@ public class Concert {
 
     // 콘서트 예약 날짜
     @Column(nullable = false)
-    private LocalDate date;
+    private LocalDateTime dateTime;
 
     // 콘서트 장소
     @Column(nullable = false)

--- a/src/main/java/com/jerry/ticketing/domain/member/Member.java
+++ b/src/main/java/com/jerry/ticketing/domain/member/Member.java
@@ -32,7 +32,7 @@ public class Member {
 
     // 멤버 패스워드
     @Column(nullable = false)
-    private String pw;
+    private String password;
 
     // 멤버 전화번호
     private String phoneNumber;

--- a/src/main/java/com/jerry/ticketing/domain/payment/Payment.java
+++ b/src/main/java/com/jerry/ticketing/domain/payment/Payment.java
@@ -44,7 +44,7 @@ public class Payment {
 
     // 결제 멱등성
     @Column(nullable = false)
-    private String idempotent;
+    private String idempotencyKey;
 
     // 결제 티켓 숫자
     @Column(nullable = false)

--- a/src/main/java/com/jerry/ticketing/domain/seat/ConcertSeat.java
+++ b/src/main/java/com/jerry/ticketing/domain/seat/ConcertSeat.java
@@ -33,6 +33,11 @@ public class ConcertSeat {
     @JoinColumn(name = "seat_id")
     private Seat seat;
 
+    // 구역 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id")
+    private Section section;
+
     // 예약 아이템 id
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_item_id")

--- a/src/main/java/com/jerry/ticketing/domain/seat/ConcertSeat.java
+++ b/src/main/java/com/jerry/ticketing/domain/seat/ConcertSeat.java
@@ -38,7 +38,7 @@ public class ConcertSeat {
     @JoinColumn(name = "reservation_item_id")
     private ReservationItem reservationItem;
 
-    // 콘서트 좌석 가격
+    // 콘서트 좌석별 가격
     private int price;
 
     // 콘서트 좌석 상태

--- a/src/main/java/com/jerry/ticketing/domain/seat/Seat.java
+++ b/src/main/java/com/jerry/ticketing/domain/seat/Seat.java
@@ -19,11 +19,6 @@ public class Seat {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 구역 id
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "section_id")
-    private Section section;
-
     // 좌석 열
     @Column(name = "seat_row")
     private String seatRow;
@@ -34,9 +29,5 @@ public class Seat {
     // 좌석 타입
     @Enumerated(EnumType.STRING)
     private SeatType seatType;
-
-    public String getFullSeatName(){
-        return String.format("%s-%s-%번", section.getZone(), seatRow, String.valueOf(number));
-    }
 
 }

--- a/src/main/java/com/jerry/ticketing/domain/seat/Section.java
+++ b/src/main/java/com/jerry/ticketing/domain/seat/Section.java
@@ -1,6 +1,7 @@
 package com.jerry.ticketing.domain.seat;
 
 
+import com.jerry.ticketing.domain.concert.Concert;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,13 +19,21 @@ public class Section {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 콘서트 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id")
+    private Concert concert;
+
     // 구역별 위치 (ex) A석, B석
+    @Column(nullable = false)
     private String zone;
 
     // 구역별 수용 인원
+    @Column(nullable = false)
     private int capacity;
 
     // 구역별 남은 좌석
+    @Column(nullable = false)
     private int remainingSeats;
 
     public int decreaseRemainingSeats(){

--- a/src/main/java/com/jerry/ticketing/dto/request/ConcertCreateRequest.java
+++ b/src/main/java/com/jerry/ticketing/dto/request/ConcertCreateRequest.java
@@ -1,0 +1,48 @@
+package com.jerry.ticketing.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.time.LocalDateTime;
+
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class ConcertCreateRequest {
+
+
+    @NotBlank(message = "콘서트 제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다")
+    private String title;
+
+    @NotNull(message = "공연 날짜는 필수입니다.")
+    @FutureOrPresent(message = "공연 날짜가 현재 또는 미래여야 합니다.")
+    private LocalDateTime dateTime;
+
+    @NotBlank(message = "공연 장소는 필수입니다.")
+    @Size(max = 100, message = "공연 장소는 100자를 초과할 수 없습니다.")
+    private String venue;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0원 이상이여야 합니다.")
+    @Max(value = 100_000_000, message = "가격은 1억원을 초과할 수 없습니다.")
+    private int price;
+
+    @Size(max = 1000, message = "설명은 1000자를 초과할 수 없습니다.")
+    private String description;
+
+    @NotNull(message = "사용자당 최대 티켓 수는 필수입니다.")
+    @Min(value = 1, message = "사용자당 최대 티켓 수는 1개 이상이여야 합니다.")
+    @Max(value = 5, message = "사용자당 최대 티켓 수는 5개 이하이여야 합니다.")
+    private int maxTicketsPerUser;
+
+
+
+}

--- a/src/main/java/com/jerry/ticketing/dto/request/SeatBlockingRequest.java
+++ b/src/main/java/com/jerry/ticketing/dto/request/SeatBlockingRequest.java
@@ -13,7 +13,9 @@ import java.util.List;
 public class SeatBlockingRequest {
 
     private Long concertId;
+
     private List<Long> seatIds;
+
     private Long memberId;
 
 }

--- a/src/main/java/com/jerry/ticketing/dto/response/ConcertResponse.java
+++ b/src/main/java/com/jerry/ticketing/dto/response/ConcertResponse.java
@@ -1,0 +1,34 @@
+package com.jerry.ticketing.dto.response;
+
+import com.jerry.ticketing.domain.concert.Concert;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ConcertResponse {
+
+    private Long id;
+    private String title;
+    private LocalDateTime dateTime;
+    private String venue;
+    private int price;
+    private String description;
+    private int maxTicketsPerUser;
+
+    public static ConcertResponse from (Concert concert){
+        return ConcertResponse.builder()
+                .id(concert.getId())
+                .title(concert.getTitle())
+                .dateTime(concert.getDateTime())
+                .venue(concert.getVenue())
+                .price(concert.getPrice())
+                .description(concert.getDescription())
+                .maxTicketsPerUser(concert.getMaxTicketsPerUser())
+                .build();
+    }
+}

--- a/src/main/java/com/jerry/ticketing/dto/response/SeatBlockingResponse.java
+++ b/src/main/java/com/jerry/ticketing/dto/response/SeatBlockingResponse.java
@@ -12,7 +12,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SeatBlockingResponse {
-    private List<Long> blockedSeatIds;
-    private LocalDateTime expireAt;
 
+    private List<Long> blockedSeatIds;
+
+    private LocalDateTime expireAt;
 }

--- a/src/main/java/com/jerry/ticketing/exception/BusinessException.java
+++ b/src/main/java/com/jerry/ticketing/exception/BusinessException.java
@@ -8,8 +8,8 @@ public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public BusinessException(ErrorCode errorCode){
-        super(errorCode.message());
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());  // RuntimeException 부모에게 콘솔에 출력되는 에러 메시지 전달
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/com/jerry/ticketing/exception/ConcertErrorCode.java
+++ b/src/main/java/com/jerry/ticketing/exception/ConcertErrorCode.java
@@ -1,0 +1,19 @@
+package com.jerry.ticketing.exception;
+
+
+public enum ConcertErrorCode implements ErrorCode {
+    CONCERT_SAVE_FAILED("콘서트 저장에 실패하였습니다.");
+
+
+    private final String message;
+
+    ConcertErrorCode(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/jerry/ticketing/exception/ErrorCode.java
+++ b/src/main/java/com/jerry/ticketing/exception/ErrorCode.java
@@ -2,8 +2,8 @@ package com.jerry.ticketing.exception;
 
 public interface ErrorCode {
         // 에러 메시지
-        String message();
+        String getMessage();
 
-        // 에러 코드 이름
+        // 에러 코드 이름 (Eum에서 자동 제공)
         String name();
 }

--- a/src/main/java/com/jerry/ticketing/exception/SeatErrorCode.java
+++ b/src/main/java/com/jerry/ticketing/exception/SeatErrorCode.java
@@ -11,7 +11,7 @@ public enum SeatErrorCode implements ErrorCode{
     }
 
     @Override
-    public String message() {
+    public String getMessage() {
         return message;
     }
 }

--- a/src/main/java/com/jerry/ticketing/repository/seat/ConcertSeatRepository.java
+++ b/src/main/java/com/jerry/ticketing/repository/seat/ConcertSeatRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface ConcertSeatRepository extends JpaRepository<ConcertSeat,Long> {
     List<ConcertSeat> findBySeatId(Long id);
 
+    List<ConcertSeat> findByConcertId(Long id);
+
     List<ConcertSeat> findByConcertIdAndSeatIdIn(Long concertId, List<Long> seatIds);
 
     List<ConcertSeat> findByBlockedExpireAtBeforeAndStatus(LocalDateTime expireTime, ConcertSeatStatus status);

--- a/src/main/java/com/jerry/ticketing/repository/seat/SectionRepository.java
+++ b/src/main/java/com/jerry/ticketing/repository/seat/SectionRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface SectionRepository extends JpaRepository<Section,Long> {
     Optional<Section> findByZone(String zone);
+
+    Optional<Section> findByConcertId(Long ConcertId);
+
+    boolean existsByConcertId(Long concertId);
 }

--- a/src/main/java/com/jerry/ticketing/repository/seat/SectionRepository.java
+++ b/src/main/java/com/jerry/ticketing/repository/seat/SectionRepository.java
@@ -1,0 +1,10 @@
+package com.jerry.ticketing.repository.seat;
+
+import com.jerry.ticketing.domain.seat.Section;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SectionRepository extends JpaRepository<Section,Long> {
+    Optional<Section> findByZone(String zone);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,4 +17,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          batch_size: 30
 

--- a/src/test/java/com/jerry/ticketing/api/concert/ConcertControllerTest.java
+++ b/src/test/java/com/jerry/ticketing/api/concert/ConcertControllerTest.java
@@ -1,0 +1,73 @@
+package com.jerry.ticketing.api.concert;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jerry.ticketing.application.concert.ConcertService;
+import com.jerry.ticketing.dto.request.ConcertCreateRequest;
+import com.jerry.ticketing.dto.response.ConcertResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(ConcertController.class)
+class ConcertControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ConcertService concertService;
+
+    @Test
+    @DisplayName("콘서트 생성 성공 테스트")
+    void createConcert_Success() throws Exception {
+        // Given
+        ConcertCreateRequest request = ConcertCreateRequest.builder()
+                .title("Test-Title")
+                .dateTime(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.MINUTES))
+                .venue("Test-Venue")
+                .price(100_000)
+                .description("Test-Description")
+                .maxTicketsPerUser(3)
+                .build();
+
+        ConcertResponse response = ConcertResponse.builder()
+                .id(1L)
+                .title("Test-Title")
+                .dateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES))
+                .venue("Test-Venue")
+                .price(100_000)
+                .description("Test-Description")
+                .maxTicketsPerUser(3)
+                .build();
+
+        when(concertService.createConcert(any(ConcertCreateRequest.class))).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/concert")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.dateTime").exists());
+
+    }
+
+}

--- a/src/test/java/com/jerry/ticketing/api/seat/SeatBlockingControllerTest.java
+++ b/src/test/java/com/jerry/ticketing/api/seat/SeatBlockingControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jerry.ticketing.application.seat.SeatBlockingService;
 import com.jerry.ticketing.domain.seat.ConcertSeat;
 import com.jerry.ticketing.dto.request.SeatBlockingRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,10 +27,14 @@ class SeatBlockingControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockitoBean
     private SeatBlockingService seatBlockingService;
 
     @Test
+    @DisplayName("좌석 점유 성공 테스트")
     void blockSeats_Success() throws Exception {
         // Given
         SeatBlockingRequest request = new SeatBlockingRequest(1L, Arrays.asList(1L, 2L), 100L);
@@ -44,7 +49,7 @@ class SeatBlockingControllerTest {
         // When & Then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/seats/block")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.blockedSeatIds.length()").value(2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.blockedSeatIds[0]").value(1))

--- a/src/test/java/com/jerry/ticketing/application/concert/ConcertServiceTest.java
+++ b/src/test/java/com/jerry/ticketing/application/concert/ConcertServiceTest.java
@@ -1,0 +1,105 @@
+package com.jerry.ticketing.application.concert;
+
+import com.jerry.ticketing.application.seat.ConcertSeatInitializer;
+import com.jerry.ticketing.domain.concert.Concert;
+import com.jerry.ticketing.dto.request.ConcertCreateRequest;
+import com.jerry.ticketing.dto.response.ConcertResponse;
+import com.jerry.ticketing.exception.BusinessException;
+import com.jerry.ticketing.exception.ConcertErrorCode;
+import com.jerry.ticketing.repository.concert.ConcertRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class ConcertServiceTest {
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @Mock
+    private ConcertSeatInitializer concertSeatInitializer;
+
+    @InjectMocks
+    private ConcertService concertService;
+
+    private Concert savedConcert;
+    private ConcertCreateRequest request;
+
+
+    @BeforeEach
+    void setUp(){
+        savedConcert = Concert.builder()
+                .id(1L)
+                .title("Test-Title")
+                .dateTime(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.MINUTES))
+                .venue("Test-Venue")
+                .price(100_000)
+                .description("Test-Description")
+                .maxTicketsPerUser(3)
+                .build();
+
+        request= ConcertCreateRequest.builder()
+                    .title("Test-Title")
+                    .dateTime(LocalDateTime.now().plusDays(1).truncatedTo(ChronoUnit.MINUTES))
+                    .venue("Test-Venue")
+                    .price(100_000)
+                    .description("Test-Description")
+                    .maxTicketsPerUser(3)
+                    .build();
+    }
+
+    @Test
+    @DisplayName("콘서트 생성 시 정상적으로 저장하고 좌석을 초기화한 후 응답을 반환")
+    void shouldCreateConcert() {
+
+        // Given
+        when(concertRepository.save(any(Concert.class))).thenReturn(savedConcert);
+        doNothing().when(concertSeatInitializer).initializeSectionAndConcertSeats(savedConcert.getId());
+
+
+        // When
+        ConcertResponse response = concertService.createConcert(request);
+
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getDateTime()).isNotNull();
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getPrice()).isEqualTo(100_000);
+
+        // 메서드 호출 검증
+        verify(concertRepository, times(1)).save(any(Concert.class));
+        verify(concertSeatInitializer, times(1)).initializeSectionAndConcertSeats(anyLong());
+
+    }
+
+
+    @Test
+    @DisplayName("콘서스 저상 실패 시 Concert Error 코드 검증")
+    void shouldThrowConcertErrorCodeWhenSaveFails(){
+
+        // Given
+        when(concertRepository.save(any(Concert.class)))
+                .thenThrow(new RuntimeException("콘서트 저장 실패"));
+
+
+        // When & Then
+        assertThatThrownBy(() -> concertService.createConcert(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ConcertErrorCode.CONCERT_SAVE_FAILED);
+    }
+}

--- a/src/test/java/com/jerry/ticketing/application/seat/integration/ConcertSeatCreationIntegrationTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/integration/ConcertSeatCreationIntegrationTest.java
@@ -1,0 +1,158 @@
+package com.jerry.ticketing.application.seat.integration;
+
+import com.jerry.ticketing.application.seat.ConcertSeatInitializer;
+import com.jerry.ticketing.application.seat.SeatInitializer;
+import com.jerry.ticketing.application.seat.SectionConfig;
+import com.jerry.ticketing.domain.concert.Concert;
+import com.jerry.ticketing.domain.seat.Section;
+import com.jerry.ticketing.repository.concert.ConcertRepository;
+import com.jerry.ticketing.repository.seat.ConcertSeatRepository;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import com.jerry.ticketing.repository.seat.SectionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ConcertSeatCreationIntegrationTest {
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Autowired
+    private SeatInitializer seatInitializer;
+
+    @Autowired
+    private SectionRepository sectionRepository;
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    @Autowired
+    private ConcertSeatInitializer concertSeatInitializer;
+
+    @Autowired
+    private ConcertSeatRepository concertSeatRepository;
+
+
+    @BeforeEach
+    void setUp(){
+        concertSeatRepository.deleteAll();
+        sectionRepository.deleteAll();
+        concertRepository.deleteAll();
+        seatRepository.deleteAll();
+    }
+
+
+    @Test
+    @DisplayName("올바른 수의 구역과 좌석을 생성 테스트")
+    void shouldCreateCorrectNumberOfSectionsAndSeats(){
+
+        // Given
+        seatInitializer.initializeSeats();
+
+        Concert concert = Concert.builder()
+                .title("Cold Play")
+                .dateTime(LocalDateTime.now())
+                .venue("일산 고양시 대화동")
+                .price(100_000)
+                .description("Cold Play의 2번째 내한 공연")
+                .maxTicketsPerUser(2)
+                .build();
+
+        Concert saveConcert = concertRepository.save(concert);
+
+        // When
+        concertSeatInitializer.initializeSectionAndConcertSeats(saveConcert.getId());
+
+        // Then
+        // 총 26개의 구역(A-Z) 생성 확인
+        assertThat(sectionRepository.count()).isEqualTo(26);
+
+        // 각 주요 구역이 ConcertId와 잘 매핑 되었는지 확인
+        Section sectionA = sectionRepository.findByZone("A").orElseThrow();
+        Section sectionG = sectionRepository.findByZone("G").orElseThrow();
+        Section sectionM = sectionRepository.findByZone("M").orElseThrow();
+
+        assertThat(sectionA.getConcert().getId()).isEqualTo(saveConcert.getId());
+        assertThat(sectionG.getConcert().getId()).isEqualTo(saveConcert.getId());
+        assertThat(sectionM.getConcert().getId()).isEqualTo(saveConcert.getId());
+
+
+        /*
+         * 전체 좌석수 확인
+         * VIP(A-F): 까지 6구역
+         * STANDARD(G-L): 까지 6구역
+         * ECONOMY(M-Z): 까지 14구역
+         * 총합: 43,000 좌석
+         * */
+
+        // 총 43,000개의 (VO) 좌석 생성 & 콘서트 좌석 확인
+        assertThat(seatRepository.count()).isEqualTo(calculateTotalSeats());
+        assertThat(concertSeatRepository.count()).isEqualTo(calculateTotalSeats());
+    }
+
+
+    @Test
+    @DisplayName("여러 콘서트에 대해 각각 올바른 수의 구역과 좌석 생성 테스트")
+    void shouldCreatCorrectSectionsAndSeatsForMultipleConcerts() {
+        // Given
+        seatInitializer.initializeSeats();
+
+        Concert concert1 = Concert.builder()
+                .title("Cold Play")
+                .dateTime(LocalDateTime.now())
+                .venue("일산 고양시 대화동")
+                .price(100_000)
+                .description("Cold Play의 2번째 내한 공연")
+                .maxTicketsPerUser(2)
+                .build();
+
+        Concert concert2 = Concert.builder()
+                .title("아이유")
+                .dateTime(LocalDateTime.now())
+                .venue("일산 고양시 마두동")
+                .price(200_000)
+                .description("아이유의 신곡 발표 콘서트")
+                .maxTicketsPerUser(3)
+                .build();
+
+        Concert saveConcert1 = concertRepository.save(concert1);
+        Concert saveConcert2 = concertRepository.save(concert2);
+
+        // When
+        concertSeatInitializer.initializeSectionAndConcertSeats(saveConcert1.getId());
+        concertSeatInitializer.initializeSectionAndConcertSeats(saveConcert2.getId());
+
+        // Then
+        // Seat(VO) 좌석은 43,000 석 생성
+        assertThat(seatRepository.count()).isEqualTo(calculateTotalSeats());
+
+
+        /*
+        * ConcertSeat 좌석은 콘서트별 생성
+        * 현재 테스트 코드의 콘서트는 2개이므로 총 86,000석 생성
+        * */
+        assertThat(concertSeatRepository.count()).isEqualTo(calculateTotalSeats() * 2L);
+
+    }
+
+
+
+    private static int calculateTotalSeats() {
+        int totalVipSeats = SectionConfig.vipSection().getCapacity() * 6;
+        int totalStandardSeats = SectionConfig.standardSection().getCapacity() * 6;
+        int totalEconomySeats = SectionConfig.economySection().getCapacity() * 14;
+        return totalVipSeats + totalStandardSeats + totalEconomySeats;
+    }
+
+
+}

--- a/src/test/java/com/jerry/ticketing/application/seat/integration/ConcertSeatInitializerTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/integration/ConcertSeatInitializerTest.java
@@ -1,0 +1,134 @@
+package com.jerry.ticketing.application.seat.integration;
+
+import com.jerry.ticketing.application.seat.ConcertSeatInitializer;
+import com.jerry.ticketing.domain.concert.Concert;
+import com.jerry.ticketing.domain.seat.ConcertSeat;
+import com.jerry.ticketing.domain.seat.Seat;
+import com.jerry.ticketing.domain.seat.Section;
+import com.jerry.ticketing.repository.concert.ConcertRepository;
+import com.jerry.ticketing.repository.seat.ConcertSeatRepository;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import com.jerry.ticketing.repository.seat.SectionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ConcertSeatInitializerTest {
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @Mock
+    private SeatRepository seatRepository;
+
+    @Mock
+    private SectionRepository sectionRepository;
+
+    @Mock
+    private ConcertSeatRepository concertSeatRepository;
+
+    @InjectMocks
+    private ConcertSeatInitializer concertSeatInitializer;
+
+    private Section mockSection;
+
+    @BeforeEach
+    void setup(){
+        // 기본 Mock 설정
+        Concert mockConcert = mock(Concert.class);
+        mockSection = mock(Section.class);
+        Seat mockSeat = mock(Seat.class);
+
+        when(concertRepository.findById(anyLong())).thenReturn(Optional.of(mockConcert));
+
+        when(seatRepository.findById(anyLong())).thenReturn(Optional.ofNullable(mockSeat));
+
+        when(sectionRepository.save(any(Section.class))).thenReturn(mockSection);
+
+    }
+
+
+    @Test
+    @DisplayName("Section에 매팽된 Concert가 없을 때 Section & ConcertSeat 초기화 메서드 호출")
+    void shouldInitializeSectionAndConcertSeatsWhenConcertNotMapped(){
+
+        // When
+       concertSeatInitializer.initializeSectionAndConcertSeats(1L);
+
+        // Then
+        // 콘서트 존재 여부 확인
+        verify(sectionRepository,times(1)).existsByConcertId(anyLong());
+
+        // Section & ConcertSeat 저장 확인
+        verify(sectionRepository, atLeastOnce()).save(any(Section.class));
+        verify(concertSeatRepository, atLeastOnce()).saveAll(anyList());
+
+    }
+
+    @Test
+    @DisplayName("이미 Section에 매핑된 Concert가 있는 경우 초기화를 건너뜀")
+    void shouldSkipInitializeSectionAndConcertSeatsWhenConcertMapped(){
+        // Given
+        when(sectionRepository.existsByConcertId(anyLong())).thenReturn(true);
+
+        // When
+        concertSeatInitializer.initializeSectionAndConcertSeats(1L);
+
+        // Then
+        verify(sectionRepository,times(1)).existsByConcertId(anyLong());
+        verify(sectionRepository, never()).save(any(Section.class));
+        verify(concertSeatRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("Section이 이미 존재할 때 기존 것을 반환 - createSectionIfNotExists 메서드 검증" )
+    void shouldReturnExistingSectionWhenExits(){
+
+        // Given
+        when(sectionRepository.findByConcertId(anyLong()))
+                .thenReturn(Optional.of(mockSection));
+
+        // When
+        concertSeatInitializer.initializeSectionAndConcertSeats(1L);
+
+        // Then
+        verify(sectionRepository, atLeastOnce()).findByConcertId(anyLong());
+        verify(sectionRepository,never()).save(any(Section.class));
+    }
+
+
+    @Test
+    @DisplayName("ConcertSeat 이미 존재할 때 기존 것을 반환 - createConcertSeats 메서드 검증")
+    void shouldReturnExistingConcertSeatWhenExits(){
+        ConcertSeat mockConcertSeat = mock(ConcertSeat.class);
+
+        // Given
+        when(sectionRepository.findByConcertId(anyLong())).thenReturn(Optional.of(mockSection));
+        when(concertSeatRepository.findByConcertId(anyLong())).thenReturn(List.of(mockConcertSeat));
+
+        // When
+        concertSeatInitializer.initializeSectionAndConcertSeats(1L);
+
+        // Then
+        verify(sectionRepository, atLeastOnce()).findByConcertId(anyLong());
+        verify(concertSeatRepository,never()).saveAll(anyList());
+
+
+    }
+
+}

--- a/src/test/java/com/jerry/ticketing/application/seat/integration/SeatInitializerIntegrationTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/integration/SeatInitializerIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.jerry.ticketing.application.seat.integration;
+
+import com.jerry.ticketing.application.seat.SeatInitializer;
+import com.jerry.ticketing.application.seat.SectionConfig;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class SeatInitializerIntegrationTest {
+
+    @Autowired
+    private SeatInitializer seatInitializer;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+
+    @BeforeEach
+    void setUp(){
+        seatRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("좌석 초기화 후 올바른 개수의 좌성이 생성되었는지 확인")
+    void shouldCreateCorrectNumberOfSeats(){
+        // Given
+        assertThat(seatRepository.count()).isEqualTo(0L);
+
+        // When
+        seatInitializer.initializeSeats();
+
+        // Then
+        // A-F까지 VIP 구역 설정 (a-e열, 1-100 좌석)
+        int seatFromAtoF = SectionConfig.calculateSeats(SectionConfig.vipSection()) * 6;
+        int seatFromGtoL = SectionConfig.calculateSeats(SectionConfig.standardSection()) * 6;
+        int seatFromMtoZ = SectionConfig.calculateSeats(SectionConfig.economySection()) * 14;
+        int seatTotal = seatFromAtoF + seatFromGtoL + seatFromMtoZ;
+
+        assertThat(seatRepository.count()).isEqualTo(seatTotal);
+    }
+}

--- a/src/test/java/com/jerry/ticketing/application/seat/unit/SeatBlockingSchedulerTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/unit/SeatBlockingSchedulerTest.java
@@ -1,13 +1,13 @@
-package com.jerry.ticketing.application.seat;
+package com.jerry.ticketing.application.seat.unit;
 
+import com.jerry.ticketing.application.seat.SeatBlockingScheduler;
+import com.jerry.ticketing.application.seat.SeatBlockingService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/com/jerry/ticketing/application/seat/unit/SeatBlockingServiceTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/unit/SeatBlockingServiceTest.java
@@ -1,5 +1,6 @@
-package com.jerry.ticketing.application.seat;
+package com.jerry.ticketing.application.seat.unit;
 
+import com.jerry.ticketing.application.seat.SeatBlockingService;
 import com.jerry.ticketing.domain.seat.ConcertSeat;
 import com.jerry.ticketing.domain.seat.enums.ConcertSeatStatus;
 import com.jerry.ticketing.exception.BusinessException;

--- a/src/test/java/com/jerry/ticketing/application/seat/unit/SeatInitializerTest.java
+++ b/src/test/java/com/jerry/ticketing/application/seat/unit/SeatInitializerTest.java
@@ -1,0 +1,62 @@
+package com.jerry.ticketing.application.seat.unit;
+
+import com.jerry.ticketing.application.seat.SeatInitializer;
+import com.jerry.ticketing.repository.seat.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SeatInitializerTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+
+    @InjectMocks
+    private SeatInitializer seatInitializer;
+
+    @BeforeEach
+    void setUp(){
+        seatRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("좌석이 없을 때 초기화하면 좌석을 생성")
+    void shouldInitializeSeatsWhenNoSeatsExist(){
+        // Given
+        when(seatRepository.count()).thenReturn(0L);
+
+        // When
+        seatInitializer.initializeSeats();
+
+        // Then
+        verify(seatRepository, times(1)).count();
+        verify(seatRepository, atLeastOnce()).saveAll(anyList());
+    }
+
+
+    @Test
+    @DisplayName("좌석이 이미 존재할 때 초기화 매서드를 호출하면 건너뜀")
+    void shouldSkipInitializationWhenNoSeatsExist(){
+        // Given
+        when(seatRepository.count()).thenReturn(1000L);
+
+        // When
+        seatInitializer.initializeSeats();
+
+        // Then
+        verify(seatRepository, times(1)).count();
+        verify(seatRepository, never()).saveAll(anyList());
+    }
+
+}

--- a/src/test/java/com/jerry/ticketing/domain/TestFixture.java
+++ b/src/test/java/com/jerry/ticketing/domain/TestFixture.java
@@ -34,7 +34,7 @@ public class TestFixture {
                 .address(Address.of("경기도","고양시"))
                 .email("jerry@naver.com")
                 .phoneNumber("010-2304-4302")
-                .pw("password") // pw 필수값 추가
+                .password("password") // pw 필수값 추가
                 .build();
     }
 
@@ -45,6 +45,7 @@ public class TestFixture {
                 .title("Cold Play")
                 .date(LocalDate.now())
                 .venue("일산 고양시 대화동")
+                .price(100_000)
                 .description("Cold Play의 2번째 내한 공연")
                 .maxTicketsPerUser(2)
                 .build();
@@ -52,8 +53,9 @@ public class TestFixture {
 
 
     // 구연 데이터 생성
-    public static Section createSection() {
+    public static Section createSection(Concert concert) {
         return Section.builder()
+                .concert(concert)
                 .zone("A")
                 .capacity(100_000)
                 .remainingSeats(100)
@@ -62,10 +64,6 @@ public class TestFixture {
 
 
     // 좌석 데이터 생성
-    public static Seat createSeat(){
-        return createSeat(createSection());
-    }
-
     public static Seat createSeat(Section section) {
         return Seat.builder()
                 .section(section)
@@ -77,10 +75,6 @@ public class TestFixture {
 
 
     // 콘서트 좌석
-    public static ConcertSeat createConcertSeat() {
-        return createConcertSeat(createConcert(), createSeat());
-    }
-
     public static ConcertSeat createConcertSeat(Concert concert, Seat seat) {
         return ConcertSeat.builder()
                 .concert(concert)
@@ -92,10 +86,6 @@ public class TestFixture {
 
 
     // 예약
-    public static Reservation createReservation(){
-        return createReservation(createMember(), createConcert());
-    }
-
     public static Reservation createReservation(Member member, Concert concert){
         return Reservation.builder()
                 .member(member)
@@ -115,7 +105,7 @@ public class TestFixture {
                 .paymentMethod(PaymentMethod.KAKAOPAY)
                 .paymentStatus(PaymentStatus.PENDING)
                 .paymentDate(LocalDate.now())
-                .idempotent("TEST-IDEMPOTENT")
+                .idempotencyKey("TEST-IDEMPOTENT")
                 .amount(3)
                 .build();
     }

--- a/src/test/java/com/jerry/ticketing/domain/TestFixture.java
+++ b/src/test/java/com/jerry/ticketing/domain/TestFixture.java
@@ -15,6 +15,8 @@ import com.jerry.ticketing.domain.seat.enums.ConcertSeatStatus;
 import com.jerry.ticketing.domain.seat.enums.SeatType;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public class TestFixture {
 
@@ -43,7 +45,7 @@ public class TestFixture {
     public static Concert createConcert() {
         return Concert.builder()
                 .title("Cold Play")
-                .date(LocalDate.now())
+                .dateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES))
                 .venue("일산 고양시 대화동")
                 .price(100_000)
                 .description("Cold Play의 2번째 내한 공연")
@@ -64,9 +66,8 @@ public class TestFixture {
 
 
     // 좌석 데이터 생성
-    public static Seat createSeat(Section section) {
+    public static Seat createSeat() {
         return Seat.builder()
-                .section(section)
                 .seatRow("A")
                 .number(10)
                 .seatType(SeatType.STANDARD)

--- a/src/test/java/com/jerry/ticketing/domain/concert/ConcertTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/concert/ConcertTest.java
@@ -38,6 +38,7 @@ class ConcertTest {
         assertThat(saveConcert).isNotNull();
         assertThat(saveConcert.getId()).isNotNull();
         assertThat(saveConcert.getTitle()).isEqualTo("Cold Play");
+        assertThat(saveConcert.getPrice()).isEqualTo(100_000);
         assertThat(saveConcert.getMaxTicketsPerUser()).isEqualTo(2);
         assertThat(saveConcert.getDate()).isEqualTo(LocalDate.now());
 

--- a/src/test/java/com/jerry/ticketing/domain/concert/ConcertTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/concert/ConcertTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,7 +41,7 @@ class ConcertTest {
         assertThat(saveConcert.getTitle()).isEqualTo("Cold Play");
         assertThat(saveConcert.getPrice()).isEqualTo(100_000);
         assertThat(saveConcert.getMaxTicketsPerUser()).isEqualTo(2);
-        assertThat(saveConcert.getDate()).isEqualTo(LocalDate.now());
+        assertThat(saveConcert.getDateTime()).isEqualTo(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES));
 
     }
 }

--- a/src/test/java/com/jerry/ticketing/domain/payment/PaymentTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/payment/PaymentTest.java
@@ -61,7 +61,7 @@ class PaymentTest {
         // Then
         assertThat(savedPayment).isNotNull();
         assertThat(savedPayment.getAmount()).isEqualTo(3);
-        assertThat(savedPayment.getIdempotent()).isEqualTo("TEST-IDEMPOTENT");
+        assertThat(savedPayment.getIdempotencyKey()).isEqualTo("TEST-IDEMPOTENT");
         assertThat(savedPayment.getPaymentMethod()).isEqualTo(PaymentMethod.KAKAOPAY);
         assertThat(savedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
     }

--- a/src/test/java/com/jerry/ticketing/domain/reservation/ReservationItemTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/reservation/ReservationItemTest.java
@@ -60,7 +60,7 @@ class ReservationItemTest {
         Member member = memberRepository.save(TestFixture.createMember());
         Concert concert = concertRepository.save(TestFixture.createConcert());
         Section section = sectionRepository.save(TestFixture.createSection(concert));
-        Seat seat = seatRepository.save(TestFixture.createSeat(section));
+        Seat seat = seatRepository.save(TestFixture.createSeat());
 
 
         ConcertSeat concertSeat = TestFixture.createConcertSeat(concert, seat);

--- a/src/test/java/com/jerry/ticketing/domain/reservation/ReservationItemTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/reservation/ReservationItemTest.java
@@ -1,5 +1,6 @@
 package com.jerry.ticketing.domain.reservation;
 
+import com.jerry.ticketing.domain.seat.Section;
 import com.jerry.ticketing.repository.concert.ConcertRepository;
 import com.jerry.ticketing.repository.member.MemberRepository;
 import com.jerry.ticketing.repository.reservation.ReservationItemRepository;
@@ -11,6 +12,7 @@ import com.jerry.ticketing.domain.concert.Concert;
 import com.jerry.ticketing.domain.member.Member;
 import com.jerry.ticketing.domain.seat.ConcertSeat;
 import com.jerry.ticketing.domain.seat.Seat;
+import com.jerry.ticketing.repository.seat.SectionRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +35,10 @@ class ReservationItemTest {
     private ConcertRepository concertRepository;
 
     @Autowired
+    private SectionRepository sectionRepository;
+
+
+    @Autowired
     private SeatRepository seatRepository;
 
     @Autowired
@@ -53,7 +59,8 @@ class ReservationItemTest {
 
         Member member = memberRepository.save(TestFixture.createMember());
         Concert concert = concertRepository.save(TestFixture.createConcert());
-        Seat seat = seatRepository.save(TestFixture.createSeat());
+        Section section = sectionRepository.save(TestFixture.createSection(concert));
+        Seat seat = seatRepository.save(TestFixture.createSeat(section));
 
 
         ConcertSeat concertSeat = TestFixture.createConcertSeat(concert, seat);

--- a/src/test/java/com/jerry/ticketing/domain/seat/ConcertSeatTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/ConcertSeatTest.java
@@ -42,7 +42,7 @@ class ConcertSeatTest {
     void setUp(){
         Concert concert = TestFixture.createConcert();
         Section section = TestFixture.createSection(concert);
-        Seat seat = TestFixture.createSeat(section);
+        Seat seat = TestFixture.createSeat();
 
         this.saveSection = sectionRepository.save(section);
         this.saveConcert = concertRepository.save(concert);

--- a/src/test/java/com/jerry/ticketing/domain/seat/ConcertSeatTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/ConcertSeatTest.java
@@ -40,8 +40,8 @@ class ConcertSeatTest {
 
     @BeforeEach
     void setUp(){
-        Section section = TestFixture.createSection();
         Concert concert = TestFixture.createConcert();
+        Section section = TestFixture.createSection(concert);
         Seat seat = TestFixture.createSeat(section);
 
         this.saveSection = sectionRepository.save(section);

--- a/src/test/java/com/jerry/ticketing/domain/seat/SeatTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/SeatTest.java
@@ -1,5 +1,6 @@
 package com.jerry.ticketing.domain.seat;
 
+import com.jerry.ticketing.domain.concert.Concert;
 import com.jerry.ticketing.repository.seat.SeatRepository;
 import com.jerry.ticketing.repository.seat.SectionRepository;
 import com.jerry.ticketing.domain.TestFixture;
@@ -32,7 +33,9 @@ class SeatTest {
     @DisplayName("예약 좌석 생성 및 저장 검증")
     void saveSeat(){
         // Given
-        Seat seat = TestFixture.createSeat();
+        Concert concert = TestFixture.createConcert();
+        Section section = TestFixture.createSection(concert);
+        Seat seat = TestFixture.createSeat(section);
 
         //When
         Seat saveSeat = seatRepository.save(seat);

--- a/src/test/java/com/jerry/ticketing/domain/seat/SeatTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/SeatTest.java
@@ -35,7 +35,7 @@ class SeatTest {
         // Given
         Concert concert = TestFixture.createConcert();
         Section section = TestFixture.createSection(concert);
-        Seat seat = TestFixture.createSeat(section);
+        Seat seat = TestFixture.createSeat();
 
         //When
         Seat saveSeat = seatRepository.save(seat);

--- a/src/test/java/com/jerry/ticketing/domain/seat/SectionTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/SectionTest.java
@@ -1,5 +1,6 @@
 package com.jerry.ticketing.domain.seat;
 
+import com.jerry.ticketing.domain.concert.Concert;
 import com.jerry.ticketing.repository.seat.SectionRepository;
 import com.jerry.ticketing.domain.TestFixture;
 import jakarta.transaction.Transactional;
@@ -22,7 +23,8 @@ class SectionTest {
     @DisplayName("구역 생성 및 저장 검증")
     void saveSection(){
         //Given
-        Section section = TestFixture.createSection();
+        Concert concert = TestFixture.createConcert();
+        Section section = TestFixture.createSection(concert);
 
         // When
         Section saveSection = sectionRepository.save(section);

--- a/src/test/java/com/jerry/ticketing/domain/seat/SectionTest.java
+++ b/src/test/java/com/jerry/ticketing/domain/seat/SectionTest.java
@@ -34,5 +34,6 @@ class SectionTest {
         assertThat(saveSection.getId()).isNotNull();
         assertThat(saveSection.getZone()).isEqualTo("A");
         assertThat(saveSection.getCapacity()).isEqualTo(100_000);
+        assertThat(saveSection.getConcert().getTitle()).isEqualTo("Cold Play");
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,7 +8,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 30
+        show_sql: false
 
   h2:
     console:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#7  (새로운 콘서트에 따른 콘서트 좌석 데이터 생성 )

## 어떤 기능인가요?
> 콘서트 등록 시 필요한 모든 데이터(concert, section, seat, concert_seat)를 초기화하는 기능입니다.
> 새로운 콘서트가 등록되면 해당 공연장의 구역(section)과 콘서트 좌석(concert seat)을 자동으로 생성합니다.

## 📝 작업 내용
> 콘서트 등록 시 필요한 모든 데이터(concert, section, seat, concert_seat)를 초기화하는 기능

### 구현 내용
- Seat를 Value Object로 설계하여 재사용 가능한 구조 구현
  - CommandLineRunner 기반 SeatInitializer 구현
  
- **콘서트 생성 시스템**
  - ConcertController 및 Service 계층 구현 (POST /api/concert)
  - 관련 DTO(Request/Response) 작성
  
- **구역 및 콘서트 좌석 연결**
  - Section 테이블을 Concert와 연결
  - ConcertSeatInitializer 구현으로 콘서트별 좌석 자동 생성
  
- **ConcertSeat 매핑 테이블 구현**
  - Concert, Section, Seat 간 관계 설계

- **성능 개선**
  - Docker 컨테이너 메모리 설정 최적화
  - JDBC batch size 설정으로 쿼리 성능 향상

### 테스트 코드
- **단위 테스트**
- **통합 테스트**
